### PR TITLE
Compatibility with newer versions of openssl

### DIFF
--- a/dpi/gemini.c
+++ b/dpi/gemini.c
@@ -638,6 +638,12 @@ static int handle_certificate_problem(SSL * ssl_connection)
       case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
          /*Either self signed and untrusted*/
          /*Extract CN from certificate name information*/
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        /*
+         * 'name' field has been removed in openssl-1.1.0 and newer
+         */
+         strcpy(buf, "('name' field removed)");
+#else
          if ((cn = strstr(remote_cert->name, "/CN=")) == NULL) {
             strcpy(buf, "(no CN given)");
          } else {
@@ -651,6 +657,7 @@ static int handle_certificate_problem(SSL * ssl_connection)
             strncpy(buf, cn, (size_t) (cn_end - cn));
             buf[cn_end - cn] = '\0';
          }
+#endif
          msg = dStrconcat("The remote certificate is self-signed and "
                           "untrusted.\nFor address: ", buf, NULL);
          d_cmd = a_Dpip_build_cmd(

--- a/src/IO/tls.c
+++ b/src/IO/tls.c
@@ -490,12 +490,26 @@ static void Tls_cert_not_valid_yet(const X509 *cert, Dstr *ds)
                      year, mon, mday, hour, min, sec);
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+int get_cert_algorithm(const X509 *cert)
+{
+    ASN1_OBJECT *ppkalg;
+    X509_PUBKEY *pubkey = X509_get_X509_PUBKEY(cert);
+    X509_PUBKEY_get0_param(&ppkalg, NULL, NULL, NULL, pubkey);
+    return OBJ_obj2nid(ppkalg);
+}
+#endif
+
 /*
  * Generate dialog msg when certificate hash algorithm is not accepted.
  */
 static void Tls_cert_bad_hash(const X509 *cert, Dstr *ds)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+   int pkey_nid = get_cert_algorithm(cert);
+#else
    int pkey_nid = OBJ_obj2nid(cert->cert_info->key->algor->algorithm);
+#endif
    const char* hash;
 
    if (pkey_nid == NID_undef) {
@@ -513,8 +527,11 @@ static void Tls_cert_bad_hash(const X509 *cert, Dstr *ds)
  */
 static void Tls_cert_bad_pk_alg(const X509 *cert, Dstr *ds)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+   int pubkey_algonid = get_cert_algorithm(cert);
+#else
    int pubkey_algonid = OBJ_obj2nid(cert->cert_info->key->algor->algorithm);
-
+#endif
    const char *algoname;
 
    if (pubkey_algonid == NID_undef) {
@@ -533,8 +550,11 @@ static void Tls_cert_bad_pk_alg(const X509 *cert, Dstr *ds)
  */
 static void Tls_cert_bad_key(const X509 *cert, Dstr *ds)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+   int pubkey_algonid = get_cert_algorithm(cert);
+#else
    int pubkey_algonid = OBJ_obj2nid(cert->cert_info->key->algor->algorithm);
-
+#endif
    const char *algoname;
 
    if (pubkey_algonid == NID_undef) {


### PR DESCRIPTION
From openssl-1.1.0 on, X509 has become an obfuscated struct, so no direct field access is now possible anymore.
This commit fixes the code using proper function calls instead.