### PR TITLE
gcc 10 and newer compatibility

### DIFF
--- a/dpid/dpid.h
+++ b/dpid/dpid.h
@@ -25,10 +25,10 @@
 
 /*! \TODO: Should read this from dillorc */
 #define SRS_NAME "dpid.srs"
-char *srs_name;
+//char *srs_name;
 
 /*! dpid's service request socket file descriptor */
-int srs_fd;
+extern int srs_fd;
 
 /*! plugin state information
  */
@@ -49,19 +49,19 @@ struct service {
 };
 
 /*! Number of available plugins */
-int numdpis;
+extern int numdpis;
 
 /*! Number of sockets being watched */
-int numsocks;
+extern int numsocks;
 
 /*! State information for each plugin. */
-struct dp *dpi_attr_list;
+extern struct dp *dpi_attr_list;
 
 /*! service served for each plugin  */
-Dlist *services_list;
+extern Dlist *services_list;
 
 /*! Set of sockets watched for connections */
-fd_set sock_set;
+extern fd_set sock_set;
 
 /*! Set to 1 by the SIGCHLD handler dpi_sigchld */
 extern volatile sig_atomic_t caught_sigchld;

--- a/dpid/dpid_common.h
+++ b/dpid/dpid_common.h
@@ -37,10 +37,12 @@
 
 
 /*! Error codes for dpid */
-enum {
+enum dpi_errno_t {
    no_errors,
    dpid_srs_addrinuse /* dpid service request socket address already in use */
-} dpi_errno;
+};
+
+extern enum dpi_errno_t dpi_errno;
 
 /*! Intended for identifying dillo plugins
  * and related files

--- a/dpid/main.c
+++ b/dpid/main.c
@@ -31,6 +31,13 @@
 #include "../dpip/dpip.h"
 
 sigset_t mask_sigchld;
+enum dpi_errno_t dpi_errno;
+struct dp *dpi_attr_list;
+Dlist *services_list;
+int numdpis;
+int numsocks;
+fd_set sock_set;
+int srs_fd;
 
 
 /* Start a dpi filter plugin after accepting the pending connection


### PR DESCRIPTION
As gcc 10+ default to -fno-common ([here](https://gcc.gnu.org/gcc-10/porting_to.html)) there are a bunch of variable definitions needing fix.
This PR takes care of them all.