### PR TITLE
Make CTRL+A select text in the current field

### DIFF
--- a/dw/fltkui.cc
+++ b/dw/fltkui.cc
@@ -173,8 +173,11 @@ int CustInput2::handle(int e)
          return 0;
       }
       if (modifier == FL_CTRL) {
-         if (k == 'a' || k == 'e') {
-            position(k == 'a' ? 0 : size());
+         if (k == 'a') {
+            position(size(), 0);
+	    return 1;
+	 } else if (k == 'e') {
+            position(size());
             return 1;
          } else if (k == 'k') {
             cut(position(), size());

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -65,8 +65,11 @@ int CustInput3::handle(int e)
    unsigned modifier = Fl::event_state() & (FL_SHIFT | FL_CTRL | FL_ALT);
 
    if (e == FL_KEYBOARD && modifier == FL_CTRL) {
-      if (k == 'a' || k == 'e') {
-         position(k == 'a' ? 0 : size());
+      if (k == 'a') {
+	 position(size(), 0);
+	 return 1;
+      } else if(k == 'e') {
+         position(size());
          return 1;
       } else if (k == 'k') {
          cut(position(), size());

--- a/src/findbar.cc
+++ b/src/findbar.cc
@@ -46,8 +46,11 @@ int MyInput::handle(int e)
             return 0;
          }
       } else if (modifier == FL_CTRL) {
-         if (k == 'a' || k == 'e') {
-            position(k == 'a' ? 0 : size());
+         if (k == 'a') {
+            position(size(), 0);
+	    return 1;
+         } else if (k == 'e') {
+            position(size());
             return 1;
          } else if (k == 'k') {
             cut(position(), size());

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -124,8 +124,11 @@ int CustInput::handle(int e)
             return 0;
          }
       } else if (modifier == FL_CTRL) {
-         if (k == 'a' || k == 'e') {
-            position(k == 'a' ? 0 : size());
+         if (k == 'a') {
+            position(size(), 0);
+	    return 1;
+	 } else if (k == 'e') {
+            position(size());
             return 1;
          } else if (k == 'k') {
             cut(position(), size());


### PR DESCRIPTION
Change the default behavior of CTRL+A from moving cursor to the beginning of the line, to selecting the whole text in the current field.
This is more intuitive for casual users and goes in pair with CTLR+X/C/V shortcuts.

Modified files:
dw/fltkui.cc <- shortcut inside the webpage
src/dialog.cc <- shortcut in a dialog (not tested) 
src/fidnbar.cc <- shortcut in Search field
src/ui.cc <- shortcut in address bar