### PR TITLE
adjust Makefile.options.OpenBSD

### DIFF
--- a/Makefile.options.OpenBSD
+++ b/Makefile.options.OpenBSD
@@ -4,8 +4,11 @@ AR ?= ar
 ARFLAGS ?= cru
 RANLIB ?= ranlib
 
-CC ?= gcc
-CXX ?= g++
+CC ?= clang
+CXX ?= clang
+# try egcc and g++ if clang fails to compile
+# CC ?= egcc
+# CXX ?= g++
 
 INSTALL ?= /usr/bin/install
 INSTALL_SH = ../install-sh

--- a/Makefile.options.OpenBSD
+++ b/Makefile.options.OpenBSD
@@ -56,10 +56,10 @@ LIBDIR = $(PREFIX)/lib/
 
 DILLO_BINDIR = $(PREFIX)/bin/
 DILLO_LIBDIR = $(PREFIX)/lib/dillo/
-DILLO_ETCDIR = $(PREFIX)/etc/dillo/
+DILLO_ETCDIR = /etc/dillo/
 
 DPIDRC_SYS = $(DILLO_ETCDIR)/dpidrc
 
 DOC_PATH = $(PREFIX)/share/doc/dillo
-MAN_PATH = $(PREFIX)/share/man/man1
+MAN_PATH = $(PREFIX)/man/man1
 


### PR DESCRIPTION
1. gcc version 4 had been in OpenBSD base, newer gcc from ports has been `egcc`
2. OpenBSD has long switched from gcc to clang. I am good in neither but dillo-plus seems to compile fine with clang, but I can't vouch - please test it yourself
3. etc path
4. man path
5. This one not added but please consider: one might wish to run `makewhatis /usr/local/man/` upon having installed a new manpage. `man dillo` will work but produce error without `makewhatis` until next weekly cron job