### PR TITLE
Fixing function signatures

### DIFF
--- a/lout/misc.hh
+++ b/lout/misc.hh
@@ -381,11 +381,11 @@ public:
       resizeMain ();
       memcpy (this->arrayMain, o.arrayMain, sizeof (T) * numMain);
 
-      this->arrayExtra = NULL;
+      this->arrayExtra1 = NULL;
       this->numExtra = o.numExtra;
       this->numAllocExtra = o.numAllocExtra;
       resizeExtra ();
-      memcpy (this->arrayExtra, o.arrayExtra, sizeof (T) * numExtra);
+      memcpy (this->arrayExtra1, o.arrayExtra1, sizeof (T) * numExtra);
 
       this->startExtra = o.startExtra;
    }

--- a/src/cache.c
+++ b/src/cache.c
@@ -1354,7 +1354,7 @@ static CacheEntry_t *Cache_process_queue(CacheEntry_t *entry)
 /*
  * Callback function for Cache_delayed_process_queue.
  */
-static void Cache_delayed_process_queue_callback()
+static void Cache_delayed_process_queue_callback(void *data)
 {
    CacheEntry_t *entry;
 

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -123,7 +123,7 @@ static void Jpeg_close(DilloJpeg *jpeg, CacheClient_t *Client)
  *    static void init_source(j_decompress_ptr cinfo)
  * (declaring it with no parameter avoids a compiler warning)
  */
-static void init_source()
+static void init_source(j_decompress_ptr cinfo)
 {
 }
 
@@ -180,7 +180,7 @@ static void skip_input_data(j_decompress_ptr cinfo, long num_bytes)
  *    static void term_source(j_decompress_ptr cinfo)
  * (declaring it with no parameter avoids a compiler warning)
  */
-static void term_source()
+static void term_source(j_decompress_ptr cinfo)
 {
 }
 


### PR DESCRIPTION
Head fails to build with function signature errors:
```
misc.hh:384:13: error: ‘class lout::misc::NotSoSimpleVector<T>’ has no member named ‘arrayExtra’
  384 |       this->arrayExtra = NULL;
```
```
cache.c:1383:26: error: passing argument 2 of ‘a_Timeout_add’ from incompatible pointer type [-Wincompatible-pointer-types]
 1383 |       a_Timeout_add(0.0, Cache_delayed_process_queue_callback, NULL);
```
```
jpeg.c:210:25: error: assignment to ‘void (*)(struct jpeg_decompress_struct *)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  210 |    src->pub.init_source = init_source;

jpeg.c:214:25: error: assignment to ‘void (*)(struct jpeg_decompress_struct *)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  214 |    src->pub.term_source = term_source;
```
I fixed them.